### PR TITLE
Improve the email core validator to be more strict with dots in usernames

### DIFF
--- a/src/validators.ts
+++ b/src/validators.ts
@@ -21,7 +21,21 @@ const isObject = (value:object) => {
  * @param {String} value
  * @returns Boolean true if `value` matches the permissive email regex
  */
-const isEmailPermissive = (value:String) => isNonEmptyString(value) && !!value.match(/^[^\s@]+@[^\s@]+\.[^\s@]+$/i)
+const isEmailPermissive = (value:String) => {
+  if(!isNonEmptyString(value)) { return false }
+
+  if(!value.match(/^[^\s@]+@[^\s@]+\.[^\s@]+$/i)) {
+    return false
+  }
+
+  const [username] = value.split('@')
+
+  if(username?.startsWith('.') || username?.endsWith('.')) {
+    return false
+  }
+
+  return true
+}
 
 /**
  * All BeSureValidators accept a single value and return a boolean indicating validation outcome

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -201,6 +201,8 @@ test('email validator', () => {
   expect( () => beSure({}, 'email')).toThrow()
   expect( () => beSure('Abc.example.com', 'email')).toThrow() // no @ character
   expect( () => beSure('A@b@c@example.com', 'email')).toThrow() // multiple @ character
+  expect( () => beSure('.test@example.com', 'email')).toThrow() // leading dot in username
+  expect( () => beSure('test.@example.com', 'email')).toThrow() // trailing dot in username
 })
 
 test('name validator', () => {


### PR DESCRIPTION
Prevent email addresses with leading or trailing dots in the username portion being treated as valid.